### PR TITLE
Update to latest webusb package

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "typescript": "~2.6.2",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
-    "webusb": "^1.0.0"
+    "webusb": "^1.0.1"
   }
 }


### PR DESCRIPTION
Updated WebUSB package to fix discovery problem on older macs. Should Fix inability to run node example.