### PR TITLE
Install nrf-intel-hex package from npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gulp-typescript": "^3.2.3",
     "gulp-uglify": "^3.0.0",
     "merge2": "^1.2.0",
-    "nrf-intel-hex": "github:arekzaluski/nrf-intel-hex#build",
+    "nrf-intel-hex": "^1.3.0",
     "progress": "^2.0.0",
     "ts-node": "^3.2.1",
     "tslint": "^5.9.1",


### PR DESCRIPTION
Tested for both web and node examples.