### PR TITLE
Fix serial data reading.

### DIFF
--- a/src/daplink/index.ts
+++ b/src/daplink/index.ts
@@ -38,11 +38,6 @@ const SERIAL_DELAY = 200;
 const PAGE_SIZE = 62;
 
 /**
- * @hidden
- */
-const SERIAL_DATA_OFFSET = 2;
-
-/**
  * DAPLink Class
  */
 export class DAPLink extends CmsisDAP implements Proxy {
@@ -161,7 +156,8 @@ export class DAPLink extends CmsisDAP implements Proxy {
                     // second byte contains the actual length of data read from the device
                     const dataLength = serialData.getUint8(1);
                     if (dataLength !== 0) {
-                        const dataArray = serialData.buffer.slice(SERIAL_DATA_OFFSET, dataLength + SERIAL_DATA_OFFSET);
+                        const offset = 2;
+                        const dataArray = serialData.buffer.slice(offset, offset + dataLength);
                         const data = String.fromCharCode.apply(null, new Uint8Array(dataArray));
                         this.emit(DAPLink.EVENT_SERIAL_DATA, data);
                     }

--- a/src/daplink/index.ts
+++ b/src/daplink/index.ts
@@ -38,6 +38,11 @@ const SERIAL_DELAY = 200;
 const PAGE_SIZE = 62;
 
 /**
+ * @hidden
+ */
+const SERIAL_DATA_OFFSET = 2;
+
+/**
  * DAPLink Class
  */
 export class DAPLink extends CmsisDAP implements Proxy {
@@ -152,10 +157,12 @@ export class DAPLink extends CmsisDAP implements Proxy {
             .then(serialData => {
                 if (serialData.byteLength > 0) {
                     // check if there is any data returned from the device
-                    // first byte contains the length of data read from the device
+                    // first byte contains the vendor code
+                    // second byte contains the actual length of data read from the device
                     const dataLength = serialData.getUint8(1);
                     if (dataLength !== 0) {
-                        const data = String.fromCharCode.apply(null, new Uint8Array(serialData.buffer.slice(1, dataLength + 2)));
+                        const dataArray = serialData.buffer.slice(SERIAL_DATA_OFFSET, dataLength + SERIAL_DATA_OFFSET);
+                        const data = String.fromCharCode.apply(null, new Uint8Array(dataArray));
                         this.emit(DAPLink.EVENT_SERIAL_DATA, data);
                     }
                 }

--- a/src/daplink/index.ts
+++ b/src/daplink/index.ts
@@ -152,8 +152,10 @@ export class DAPLink extends CmsisDAP implements Proxy {
             .then(serialData => {
                 if (serialData.byteLength > 0) {
                     // check if there is any data returned from the device
-                    if (serialData.getUint8(1) !== 0) {
-                        const data = String.fromCharCode.apply(null, new Uint8Array(serialData.buffer.slice(1)));
+                    // first byte contains the length of data read from the device
+                    const dataLength = serialData.getUint8(1);
+                    if (dataLength !== 0) {
+                        const data = String.fromCharCode.apply(null, new Uint8Array(serialData.buffer.slice(1, dataLength + 2)));
                         this.emit(DAPLink.EVENT_SERIAL_DATA, data);
                     }
                 }


### PR DESCRIPTION
Usb and Webusb transport layer returns extra data in serial buffer. With this fix dapjs will read only the amount of data that is returned by DAPLink.
It needs to be investigated why buffer is not cleaned properly when usb and webusb transport is being used. Issue can't be reproduced for node hid layer.