### PR TITLE
Apply stricter type checks and remove Node.js dependency from DAPLink

### DIFF
--- a/src/daplink/index.ts
+++ b/src/daplink/index.ts
@@ -54,7 +54,7 @@ export class DAPLink extends CmsisDAP implements Proxy {
      */
     public static EVENT_SERIAL_DATA: string = "serial";
 
-    private timer: NodeJS.Timer = null;
+    private timer: any = null;
 
     /**
      * Detect if buffer contains text or binary data
@@ -86,6 +86,8 @@ export class DAPLink extends CmsisDAP implements Proxy {
             this.emit(DAPLink.EVENT_PROGRESS, offset / buffer.byteLength);
             if (end < buffer.byteLength) {
                 return this.writeBuffer(buffer, pageSize, end);
+            } else {
+                return Promise.resolve();
             }
         });
     }
@@ -116,7 +118,7 @@ export class DAPLink extends CmsisDAP implements Proxy {
         })
         .then(result => {
             // An error occurred
-            if (result.getUint8(1) !== 0) return;
+            if (result.getUint8(1) !== 0) return Promise.reject("Flash error");
             return this.send(DAPLinkFlash.RESET);
         })
         .then(() => undefined);

--- a/src/processor/cortex-m.ts
+++ b/src/processor/cortex-m.ts
@@ -174,7 +174,7 @@ export class CortexM extends ADI implements Processor {
      * @returns Promise of register values in an array
      */
     public readCoreRegisters(registers: CoreRegister[]): Promise<number[]> {
-        let chain = Promise.resolve([]);
+        let chain: Promise<number[]> = Promise.resolve([]);
 
         registers.forEach(register => {
             chain = chain.then(results => this.readCoreRegister(register).then(result => [...results, result]));
@@ -212,7 +212,7 @@ export class CortexM extends ADI implements Processor {
      * @param linkRegister The link register to use (defaults to address + 1)
      * @param registers Values to add to the general purpose registers, R0, R1, R2, etc.
      */
-    public execute(address: number, code: Uint32Array, stackPointer: number, programCounter: number, linkRegister: number = address + 1, ...registers: number[]): Promise<number> {
+    public execute(address: number, code: Uint32Array, stackPointer: number, programCounter: number, linkRegister: number = address + 1, ...registers: number[]): Promise<void> {
 
         // Ensure a breakpoint exists at the end of the code
         if (code[code.length - 1] !== BKPT_INSTRUCTION) {

--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -87,7 +87,7 @@ export interface Processor extends DAP {
      * @param linkRegister The link register to use (defaults to address + 1)
      * @param registers Values to add to the general purpose registers, R0, R1, R2, etc.
      */
-    execute(address: number, code: Uint32Array, stackPointer: number, programCounter: number, linkRegister?: number, ...registers: number[]): Promise<number>;
+    execute(address: number, code: Uint32Array, stackPointer: number, programCounter: number, linkRegister?: number, ...registers: number[]): Promise<void>;
 }
 
 export { CortexM } from "./cortex-m";

--- a/src/proxy/cmsis-dap.ts
+++ b/src/proxy/cmsis-dap.ts
@@ -310,8 +310,8 @@ export class CmsisDAP extends EventEmitter implements Proxy {
         if (typeof portOrOps === "number") {
             operations = [{
                 port: portOrOps,
-                mode,
-                register,
+                mode: mode ? mode : DAPTransferMode.WRITE,
+                register: register ? register : 0,
                 value
             }];
         } else {
@@ -332,7 +332,7 @@ export class CmsisDAP extends EventEmitter implements Proxy {
             // Transfer request
             view.setUint8(offset, operation.port | operation.mode | operation.register);
             // Transfer data
-            view.setUint32(offset + 1, operation.value, true);
+            view.setUint32(offset + 1, operation.value ? operation.value : 0, true);
         });
 
         return this.send(DAPCommand.DAP_TRANSFER, data)
@@ -440,6 +440,8 @@ export class CmsisDAP extends EventEmitter implements Proxy {
 
             if (typeof countOrValues === "number") {
                 return new Uint32Array(result.buffer.slice(4));
+            } else {
+                return;
             }
         });
     }

--- a/src/transport/hid.ts
+++ b/src/transport/hid.ts
@@ -31,8 +31,8 @@ import { Transport } from "./";
 export class HID implements Transport {
 
     private os: string = platform();
-    private path: string = null;
-    private device: nodeHID = null;
+    private path?: string;
+    private device?: nodeHID;
     public readonly packetSize = 64;
 
     /**
@@ -53,7 +53,7 @@ export class HID implements Transport {
      */
     public open(): Promise<void> {
         return new Promise((resolve, reject) => {
-            if (!this.path.length) {
+            if (!this.path) {
                 return reject("No path specified");
             }
 
@@ -74,7 +74,7 @@ export class HID implements Transport {
         return new Promise((resolve, _reject) => {
             if (this.device) {
                 this.device.close();
-                this.device = null;
+                this.device = undefined;
             }
 
             resolve();
@@ -87,6 +87,10 @@ export class HID implements Transport {
      */
     public read(): Promise<DataView> {
         return new Promise((resolve, reject) => {
+            if (!this.device) {
+                return reject("device not open");
+            }
+
             this.device.read((error: string, data: number[]) => {
                 if (error) {
                     return reject(error);
@@ -107,6 +111,10 @@ export class HID implements Transport {
         return new Promise((resolve, reject) => {
             function isView(source: ArrayBuffer | ArrayBufferView): source is ArrayBufferView {
                 return (source as ArrayBufferView).buffer !== undefined;
+            }
+
+            if (!this.device) {
+                return reject("device not open");
             }
 
             const arrayBuffer = isView(data) ? data.buffer : data;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
         "noUnusedParameters": true,
         "noImplicitAny": true,
         "sourceMap": true,
-        "declaration": true
+        "declaration": true,
+        "strictNullChecks": true,
+        "noImplicitReturns": true,
     }
 }


### PR DESCRIPTION
- Apply stricter TS rules: strictNullChecks and noImplictReturns
- TypeScript 3.0 compliance
- Remove NodeJS.Timer from DAPLink

A first step towards #35 