### PR TITLE
Remove node types from web output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DAP.js is a JavaScript interface to [CMSIS-DAP](https://www.keil.com/pack/doc/CM
 
 ## Prerequisites
 
-[Node.js > v6.10.0](https://nodejs.org), which includes `npm`
+[Node.js > v6.15.0](https://nodejs.org), which includes `npm`
 
 ## Installation
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,9 +99,6 @@ function bundle() {
     return browserify(nodeDir, {
         standalone: bundleGlobal
     })
-    .ignore("webusb")
-    .ignore("usb")
-    .ignore("node-hid")
     .bundle()
     .on("error", handleError)
     .pipe(source(bundleFile))

--- a/package.json
+++ b/package.json
@@ -4,11 +4,9 @@
   "description": "JavaScript interface to on-chip debugger (CMSIS-DAP)",
   "homepage": "https://github.com/ARMmbed/dapjs",
   "license": "MIT",
-  "types": "./types/index.d.ts",
-  "main": "./index.js",
-  "browser": {
-    "./index.js": "./bundles/dap.bundle.js"
-  },
+  "main": "lib/index.js",
+  "browser": "lib/browser.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/ARMmbed/dapjs.git"

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,6 @@
 /*
-* The MIT License (MIT)
+* DAPjs
+* Copyright Arm Limited 2018
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -20,4 +21,8 @@
 * SOFTWARE.
 */
 
-module.exports = require("./lib/");
+export { CmsisDAP } from "./proxy";
+export { DAPLink } from "./daplink";
+export { ADI } from "./dap";
+export { CortexM } from "./processor";
+export { WebUSB } from "./transport/webusb";

--- a/src/daplink/index.ts
+++ b/src/daplink/index.ts
@@ -54,7 +54,7 @@ export class DAPLink extends CmsisDAP implements Proxy {
      */
     public static EVENT_SERIAL_DATA: string = "serial";
 
-    private timer?: NodeJS.Timer;
+    private timer?: any;
 
     /**
      * Detect if buffer contains text or binary data

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,10 @@
 * SOFTWARE.
 */
 
-export { HID, USB, WebUSB } from "./transport";
 export { CmsisDAP } from "./proxy";
 export { DAPLink } from "./daplink";
 export { ADI } from "./dap";
 export { CortexM } from "./processor";
+export { HID } from "./transport/hid";
+export { USB } from "./transport/usb";
+export { WebUSB } from "./transport/webusb";

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -55,7 +55,3 @@ export interface Transport {
      */
     write(data: BufferSource): Promise<void>;
 }
-
-export { HID } from "./hid";
-export { USB } from "./usb";
-export { WebUSB } from "./webusb";

--- a/src/transport/usb.ts
+++ b/src/transport/usb.ts
@@ -89,7 +89,7 @@ export class USB implements Transport {
         }
 
         const arrayBuffer = isView(bufferSource) ? bufferSource.buffer : bufferSource;
-        return new Buffer(arrayBuffer);
+        return Buffer.from(arrayBuffer);
     }
 
     private extendBuffer(data: BufferSource, packetSize: number): BufferSource {


### PR DESCRIPTION
Note: Relies on #40 to be merged first.

This PR removes the usage of `NodeJS.Timer` and reworks the `package.json` entry points so that web users shouldn't come across any NodeJS types when using DAPjs with TypeScript.

This is undertaken by removing the `HID` and `USB` transports from the web entry point leaving just the `WebUSB` wrapper.

cc @philipphenkel, @Taylor-Woodcock