### PR TITLE
Introduce new web examples

### DIFF
--- a/examples/daplink-serial/web.html
+++ b/examples/daplink-serial/web.html
@@ -1,0 +1,55 @@
+<!--
+ DAPjs
+ Copyright Arm Limited 2018
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+-->
+
+<!DOCTYPE html>
+<html>
+<body>
+    <button id="connect">Connect</button>
+    <div id="results" style="white-space: pre;" />
+
+    <script type="text/javascript" src="../../dist/dap.umd.js"></script>
+    <script>
+
+        // Listen to serial output from the device
+        const listen = async (device, resultsEl) => {
+            const transport = new DAPjs.WebUSB(device);
+            const target = new DAPjs.DAPLink(transport);
+
+            target.on(DAPjs.DAPLink.EVENT_SERIAL_DATA, data => {
+                resultsEl.innerHTML += `${data}`;
+            });
+
+            await target.connect();
+            const baud = await target.getSerialBaudrate();
+            target.startSerialRead();
+            resultsEl.innerHTML = `Listening at ${baud} baud...\n`;
+        };
+
+        document.getElementById("connect").onclick = async () => {
+            const resultsEl = document.getElementById("results");
+            const device = await navigator.usb.requestDevice({
+                filters: [{vendorId: 0xD28}]
+            });
+
+            listen(device, resultsEl);
+        };
+    </script>
+</body>
+</html>

--- a/examples/read-registers/common.js
+++ b/examples/read-registers/common.js
@@ -55,9 +55,6 @@ function readRegisters(transport) {
         registers.forEach((register, index) => {
             console.log(`R${index}: ${("00000000" + register.toString(16)).slice(-8)}`);
         });
-        return processor.reconnect();
-    })
-    .then(() => {
         return processor.resume();
     })
     .then(() => {

--- a/examples/read-registers/web.html
+++ b/examples/read-registers/web.html
@@ -1,0 +1,66 @@
+<!--
+ DAPjs
+ Copyright Arm Limited 2018
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+-->
+
+<!DOCTYPE html>
+<html>
+<body>
+    <button id="read">Read Registers</button>
+
+    <script type="text/javascript" src="../../dist/dap.umd.js"></script>
+    <script>
+        const count = 16;
+
+        const readRegisters = async (device, count) => {
+            const transport = new DAPjs.WebUSB(device);
+            const processor = new DAPjs.CortexM(transport);
+
+            await processor.connect();
+            await processor.halt();
+
+            const registers = Array.from({ length: count }, (_, index) => index);
+            const values = await processor.readCoreRegisters(registers);
+
+            await processor.resume();
+            await processor.disconnect();
+
+            const result = values.map(register => ("00000000" + register.toString(16)).slice(-8));
+            return result;
+        };
+
+        document.getElementById("read").onclick = async () => {
+            const device = await navigator.usb.requestDevice({
+                filters: [{vendorId: 0xD28}]
+            });
+            const values = await readRegisters(device, count);
+            values.forEach((value, index) => {
+                const registerEl = document.getElementById(`r${index}`);
+                registerEl.innerHTML = `Register ${index}: ${value}`;
+            });
+        };
+
+        for (let index = 0; index < count; index++) {
+            const registerEl = document.createElement("div");
+            registerEl.id = `r${index}`;
+            registerEl.innerHTML = `Register ${index}: None`;
+            document.body.appendChild(registerEl);
+        }
+    </script>
+</body>
+</html>

--- a/examples/typescript/registers.ts
+++ b/examples/typescript/registers.ts
@@ -45,7 +45,6 @@ export class Registers {
             const registers = Array.from({ length: count }, (_, index) => index);
             const values = await processor.readCoreRegisters(registers);
 
-            await processor.reconnect();
             await processor.resume();
             await processor.disconnect();
 


### PR DESCRIPTION
This PR updates the examples in two ways:

- Adds two new web examples (serial reading and register reading)
- Removes unneeded `reconnect()` from existing examples

This PR relies on #47 being merged first