### PR TITLE
Support bulk endpoints

### DIFF
--- a/src/transport/usb.ts
+++ b/src/transport/usb.ts
@@ -123,7 +123,14 @@ export class USB implements Transport {
                     throw new Error("No valid interfaces found.");
                 }
 
-                const selectedInterface = interfaces[0];
+                // Prefer interface with endpoints
+                let selectedInterface = interfaces.find(iface => iface.endpoints.length > 0);
+
+                // Otherwise use the first
+                if (!selectedInterface) {
+                    selectedInterface = interfaces[0];
+                }
+
                 this.interfaceNumber = selectedInterface.interfaceNumber;
 
                 // If we always want to use control transfer, don't find/set endpoints and claim interface

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "lib": [
             "es5",
             "dom",
+            "es2015.core",
             "es2015.promise"
         ],
         "strict": true,


### PR DESCRIPTION
With the addition of [CMSIS v2 Bulk Endpoint support in DapLink](https://github.com/ARMmbed/DAPLink/pull/629), this PR updates DAPjs to take advantage of this read/write method when available.

Tested with all examples on `K64F` using:

- Existing firmware without bulk endpoint support
- Bulk endpoint firmware with HID interrupt
- Bulk endpoint firmware without HID interrupt

cc @flit, @brianesquilona, @jaustin 
