### PR TITLE
Serial refactor

### DIFF
--- a/examples/daplink-serial/common.js
+++ b/examples/daplink-serial/common.js
@@ -40,7 +40,7 @@ function listen(transport) {
     const target = new DAPjs.DAPLink(transport);
 
     target.on(DAPjs.DAPLink.EVENT_SERIAL_DATA, data => {
-        console.log(data);
+        process.stdout.write(data);
     });
 
     return target.connect()

--- a/examples/daplink-serial/web.html
+++ b/examples/daplink-serial/web.html
@@ -38,8 +38,10 @@
 
             await target.connect();
             const baud = await target.getSerialBaudrate();
-            target.startSerialRead();
+            await target.disconnect();
             resultsEl.innerHTML = `Listening at ${baud} baud...\n`;
+
+            target.startSerialRead();
         };
 
         document.getElementById("connect").onclick = async () => {

--- a/src/daplink/index.ts
+++ b/src/daplink/index.ts
@@ -38,10 +38,6 @@ const DEFAULT_SERIAL_DELAY = 100;
  * @hidden
  */
 const DEFAULT_PAGE_SIZE = 62;
-/**
- * @hidden
- */
-const SERIAL_VENDOR_CODE = 131;
 
 /**
  * DAPLink Class
@@ -214,7 +210,7 @@ export class DAPLink extends CmsisDAP {
             }
 
             // First byte contains the vendor code
-            if (serialData.getUint8(0) !== SERIAL_VENDOR_CODE) {
+            if (serialData.getUint8(0) !== DAPLinkSerial.READ) {
                 return undefined;
             }
 

--- a/src/daplink/index.ts
+++ b/src/daplink/index.ts
@@ -21,6 +21,7 @@
 * SOFTWARE.
 */
 
+import { StringDecoder } from "string_decoder";
 import { CmsisDAP, DAPProtocol, DEFAULT_CLOCK_FREQUENCY } from "../proxy";
 import { Transport } from "../transport";
 import { DAPLinkFlash, DAPLinkSerial } from "./enums";
@@ -256,9 +257,9 @@ export class DAPLink extends CmsisDAP {
                 }
 
                 if (serialData !== undefined) {
-                    const numberArray = Array.prototype.slice.call(new Uint8Array(serialData));
-                    const data = String.fromCharCode.apply(null, numberArray);
-                    this.emit(DAPLink.EVENT_SERIAL_DATA, data);
+                    const buffer = Buffer.from(serialData);
+                    const decoder = new StringDecoder("utf8");
+                    this.emit(DAPLink.EVENT_SERIAL_DATA, decoder.write(buffer));
                 }
             }
 

--- a/src/daplink/index.ts
+++ b/src/daplink/index.ts
@@ -21,7 +21,7 @@
 * SOFTWARE.
 */
 
-import { StringDecoder } from "string_decoder";
+import { TextDecoder } from "./text-decoder";
 import { CmsisDAP, DAPProtocol, DEFAULT_CLOCK_FREQUENCY } from "../proxy";
 import { Transport } from "../transport";
 import { DAPLinkFlash, DAPLinkSerial } from "./enums";
@@ -38,6 +38,11 @@ const DEFAULT_SERIAL_DELAY = 100;
  * @hidden
  */
 const DEFAULT_PAGE_SIZE = 62;
+
+/**
+ * @hidden
+ */
+const decoder = new TextDecoder();
 
 /**
  * DAPLink Class
@@ -253,9 +258,8 @@ export class DAPLink extends CmsisDAP {
                 }
 
                 if (serialData !== undefined) {
-                    const buffer = Buffer.from(serialData);
-                    const decoder = new StringDecoder("utf8");
-                    this.emit(DAPLink.EVENT_SERIAL_DATA, decoder.write(buffer));
+                    const data = decoder.decode(serialData);
+                    this.emit(DAPLink.EVENT_SERIAL_DATA, data);
                 }
             }
 

--- a/src/daplink/text-decoder.ts
+++ b/src/daplink/text-decoder.ts
@@ -1,0 +1,86 @@
+/*
+* DAPjs
+* Copyright Arm Limited 2020
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+// https://github.com/anonyco/FastestSmallestTextEncoderDecoder
+
+const PARTIAL_CHAR_TEST = /[\xc0-\xff][\x80-\xbf]*$/g;
+const DOUBLE_BYTE_REPLACE = /[\xc0-\xff][\x80-\xbf]*/g;
+
+export class TextDecoder {
+
+    private partialChar: string | undefined;
+
+    /**
+     * Decode an ArrayBuffer to a string, handling double-byte characters
+     * @param input The ArrayBuffer to decode
+     */
+    public decode(input: ArrayBuffer): string {
+
+        const numberArray = Array.prototype.slice.call(new Uint8Array(input));
+        let data = String.fromCodePoint.apply(undefined, numberArray);
+
+        if (this.partialChar) {
+            // Previous double-byte character was cut off
+            data = `${this.partialChar}${data}`;
+            this.partialChar = undefined;
+        }
+
+        const match = data.match(PARTIAL_CHAR_TEST);
+        if (match) {
+            // Partial double-byte character at end of string, save it and truncate data
+            const length = match[0].length;
+            this.partialChar = data.slice(-length);
+            data = data.slice(0, -length);
+        }
+
+        return data.replace(DOUBLE_BYTE_REPLACE, this.decoderReplacer);
+    }
+
+    private decoderReplacer(encoded: string): string {
+        let codePoint = encoded.codePointAt(0)! << 24;
+        const leadingOnes = Math.clz32(~codePoint);
+        let endPos = 0;
+        const stringLen = encoded.length;
+        let result = "";
+        if (leadingOnes < 5 && stringLen >= leadingOnes) {
+            codePoint = (codePoint << leadingOnes) >>> (24 + leadingOnes);
+            for (endPos = 1; endPos < leadingOnes; endPos = endPos + 1) {
+                codePoint = (codePoint << 6) | (encoded.codePointAt(endPos)! & 0x3f);
+            }
+            if (codePoint <= 0xFFFF) { // BMP code point
+                result += String.fromCodePoint(codePoint);
+            } else if (codePoint <= 0x10FFFF) {
+                // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+                codePoint = codePoint - 0x10000;
+                result += String.fromCodePoint(
+                    (codePoint >> 10) + 0xD800,  // highSurrogate
+                    (codePoint & 0x3ff) + 0xDC00 // lowSurrogate
+                );
+            } else endPos = 0; // to fill it in with INVALIDs
+        }
+        for (; endPos < stringLen; endPos = endPos + 1) {
+            result += "\ufffd"; // replacement character
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
This PR updates the serial output code, specifically:

- Exposes the raw SerialRead function
- Uses `setTimeout` instead of `setInterval` while polling serial output to eradicate any overlap
- Reduced default serial poll to 100 ms
- Text decode updated to support double-byte characters
- Confirmed to support strings of more than 64 chars
- Added guard against incorrect VENDOR_CODE_COMMAND result being output
- Added connection status to target and guards against re-connect/re-disconnect
- Only polls serial output when there is a relevant event listener present
- Added auto-connect functionality to only open target connection during each read

Resolves #60 and may fix #51 

cc @microbit-sam, @jaustin, @microbit-carlos