### PR TITLE
Fix endpoint detection

### DIFF
--- a/src/transport/usb.ts
+++ b/src/transport/usb.ts
@@ -120,7 +120,7 @@ export class USB implements Transport {
         await new Promise((resolve, reject) => {
             this.device.setConfiguration(this.configuration, error => {
                 if (error) {
-                    reject(new Error(error.message));
+                    reject(new Error(error));
                 } else {
                     resolve();
                 }

--- a/src/transport/usb.ts
+++ b/src/transport/usb.ts
@@ -153,8 +153,8 @@ export class USB implements Transport {
             this.endpointOut = undefined;
 
             for (const endpoint of endpoints) {
-                if (endpoint.direction === 'in') this.endpointIn = (endpoint as InEndpoint);
-                else this.endpointOut = (endpoint as OutEndpoint);
+                if (endpoint.direction === 'in' && !this.endpointIn) this.endpointIn = (endpoint as InEndpoint);
+                else if (endpoint.direction === 'out' && !this.endpointOut) this.endpointOut = (endpoint as OutEndpoint);
             }
 
             // If endpoints are found, claim the interface

--- a/src/transport/usb.ts
+++ b/src/transport/usb.ts
@@ -120,7 +120,7 @@ export class USB implements Transport {
         await new Promise((resolve, reject) => {
             this.device.setConfiguration(this.configuration, error => {
                 if (error) {
-                    reject(new Error(error));
+                    reject(new Error(error.message));
                 } else {
                     resolve();
                 }

--- a/src/transport/webusb.ts
+++ b/src/transport/webusb.ts
@@ -118,8 +118,8 @@ export class WebUSB implements Transport {
             this.endpointOut = undefined;
 
             for (const endpoint of endpoints) {
-                if (endpoint.direction === 'in') this.endpointIn = endpoint;
-                else this.endpointOut = endpoint;
+                if (endpoint.direction === 'in' && !this.endpointIn) this.endpointIn = endpoint;
+                else if (endpoint.direction === 'out' && !this.endpointOut) this.endpointOut = endpoint;
             }
         }
 


### PR DESCRIPTION
PR to fix the endpoint detection for USB and WebUSB devices that have multiple endpoints behind a single device interface.
It assumes that debug communication happens over the first detected 'in' endpoint, and 'out' endpoint respectively.