### PR TITLE
Implemented 1-byte memory operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ The `DAP` (Debug Access Port) layer exposes low-level access to ports, registers
 - [x] writeDP()
 - [x] readAP()
 - [x] writeAP()
+- [x] readMem8()
+- [x] writeMem8()
 - [x] readMem16()
 - [x] writeMem16()
 - [x] readMem32()

--- a/src/dap/adi.ts
+++ b/src/dap/adi.ts
@@ -314,7 +314,7 @@ export class ADI implements DAP {
      */
     public async readMem8(register: number): Promise<number> {
         const result = await this.proxy.transfer(this.readMem8Command(register));
-        return result[0];
+        return result[0] as number >> ((register & 0x03) << 3) & 0xFF;
     }
 
     /**
@@ -335,7 +335,7 @@ export class ADI implements DAP {
      */
     public async readMem16(register: number): Promise<number> {
         const result = await this.proxy.transfer(this.readMem16Command(register));
-        return result[0];
+        return result[0] as number >> ((register & 0x02) << 3) & 0xFFFF;
     }
 
     /**

--- a/src/dap/adi.ts
+++ b/src/dap/adi.ts
@@ -166,6 +166,18 @@ export class ADI implements DAP {
         });
     }
 
+    protected readMem8Command(register: number): DAPOperation[] {
+        return this.writeAPCommand(APRegister.CSW, CSWMask.VALUE | CSWMask.SIZE_8)
+        .concat(this.writeAPCommand(APRegister.TAR, register))
+        .concat(this.readAPCommand(APRegister.DRW));
+    }
+
+    protected writeMem8Command(register: number, value: number): DAPOperation[] {
+        return this.writeAPCommand(APRegister.CSW, CSWMask.VALUE | CSWMask.SIZE_8)
+        .concat(this.writeAPCommand(APRegister.TAR, register))
+        .concat(this.writeAPCommand(APRegister.DRW, value));
+    }
+
     protected readMem16Command(register: number): DAPOperation[] {
         return this.writeAPCommand(APRegister.CSW, CSWMask.VALUE | CSWMask.SIZE_16)
         .concat(this.writeAPCommand(APRegister.TAR, register))
@@ -293,6 +305,27 @@ export class ADI implements DAP {
      */
     public async writeAP(register: APRegister, value: number): Promise<void> {
         await this.proxy.transfer(this.writeAPCommand(register, value));
+    }
+
+    /**
+     * Read an 8-bit word from a memory access port register
+     * @param register ID of register to read
+     * @returns Promise of register data
+     */
+    public async readMem8(register: number): Promise<number> {
+        const result = await this.proxy.transfer(this.readMem8Command(register));
+        return result[0];
+    }
+
+    /**
+     * Write an 8-bit word to a memory access port register
+     * @param register ID of register to write to
+     * @param value The value to write
+     * @returns Promise
+     */
+    public async writeMem8(register: number, value: number): Promise<void> {
+        value = value as number << ((register & 0x03) << 3);
+        await this.proxy.transfer(this.writeMem8Command(register, value));
     }
 
     /**

--- a/src/dap/index.ts
+++ b/src/dap/index.ts
@@ -80,6 +80,21 @@ export interface DAP {
     writeAP(register: number, value: number): Promise<void>;
 
     /**
+     * Read an 8-bit word from a memory access port register
+     * @param register ID of register to read
+     * @returns Promise of register data
+     */
+    readMem8(register: number): Promise<number>;
+
+    /**
+     * Write an 8-bit word to a memory access port register
+     * @param register ID of register to write to
+     * @param value The value to write
+     * @returns Promise
+     */
+    writeMem8(register: number, value: number): Promise<void>;
+
+    /**
      * Read a 16-bit word from a memory access port register
      * @param register ID of register to read
      * @returns Promise of register data


### PR DESCRIPTION
Added an implementation of `readMem8()` and `writeMem()` modeled after the other 16-bit and 32-bit memory operations (tested on a Cortex-M4 system).