### PR TITLE
Implementation of readBytes() and writeBytes() + RTT console fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ The `DAP` (Debug Access Port) layer exposes low-level access to ports, registers
 - [x] writeMem32()
 - [x] readBlock()
 - [x] writeBlock()
+- [x] readBytes()
+- [x] writeBytes()
 
 ### Processor
 

--- a/examples/rtt/rtt.js
+++ b/examples/rtt/rtt.js
@@ -109,33 +109,16 @@ class RTT {
         }).join('')
     }
 
-    async readBytes (addr, size) {
-        var sizeToRead = size;
-        let startOffset = addr % 4;
-        let endOffset = (addr + size) % 4;
-
-        if (startOffset) {
-            addr -= startOffset;
-            sizeToRead += startOffset;
-        }
-
-        if (endOffset)
-            sizeToRead += (4 - endOffset);
-
-        var data32 = await this.processor.readBlock(addr, sizeToRead / 4);
-        return new Uint8Array(data32.buffer).slice(startOffset, startOffset + size);
-    }
-
     async read (bufId) {
         var buf = this.bufUp[bufId];
 
         buf.WrOff = await this.processor.readMem32(buf.bufAddr + 12);
 
         if (buf.WrOff > buf.RdOff) {
-            var data = await this.readBytes(buf.pBuffer + buf.RdOff, buf.WrOff - buf.RdOff);
+            var data = await processor.readBytes(buf.pBuffer + buf.RdOff, buf.WrOff - buf.RdOff);
         } else if (buf.WrOff < buf.RdOff) {
-            let data1 = await this.readBytes(buf.pBuffer + buf.RdOff, buf.SizeOfBuffer - buf.RdOff);
-            let data2 = await this.readBytes(buf.pBuffer, buf.WrOff);
+            let data1 = await processor.readBytes(buf.pBuffer + buf.RdOff, buf.SizeOfBuffer - buf.RdOff);
+            let data2 = await processor.readBytes(buf.pBuffer, buf.WrOff);
             var data = new Uint8Array(data1.length + data2.length);
             data.set(data1, 0);
             data.set(data2, data1.length);

--- a/examples/rtt/rtt.js
+++ b/examples/rtt/rtt.js
@@ -112,6 +112,7 @@ class RTT {
     async read (bufId) {
         var buf = this.bufUp[bufId];
 
+        buf.RdOff = await this.processor.readMem32(buf.bufAddr + 16);
         buf.WrOff = await this.processor.readMem32(buf.bufAddr + 12);
 
         if (buf.WrOff > buf.RdOff) {
@@ -136,6 +137,7 @@ class RTT {
         var buf = this.bufDown[bufId];
 
         buf.RdOff = await this.processor.readMem32(buf.bufAddr + 16);
+        buf.WrOff = await this.processor.readMem32(buf.bufAddr + 12);
 
         if (buf.WrOff >= buf.RdOff)
             var num_avail = buf.SizeOfBuffer - (buf.WrOff - buf.RdOff);

--- a/examples/rtt/rtt.js
+++ b/examples/rtt/rtt.js
@@ -40,7 +40,7 @@ class RTT {
         this.processor = processor;
     }
 
-    async init (processor) {
+    async init () {
         let scanBlockSize = 0x1000 ;
         let scanStride = 0x0800;
 
@@ -115,10 +115,10 @@ class RTT {
         buf.WrOff = await this.processor.readMem32(buf.bufAddr + 12);
 
         if (buf.WrOff > buf.RdOff) {
-            var data = await processor.readBytes(buf.pBuffer + buf.RdOff, buf.WrOff - buf.RdOff);
+            var data = await this.processor.readBytes(buf.pBuffer + buf.RdOff, buf.WrOff - buf.RdOff);
         } else if (buf.WrOff < buf.RdOff) {
-            let data1 = await processor.readBytes(buf.pBuffer + buf.RdOff, buf.SizeOfBuffer - buf.RdOff);
-            let data2 = await processor.readBytes(buf.pBuffer, buf.WrOff);
+            let data1 = await this.processor.readBytes(buf.pBuffer + buf.RdOff, buf.SizeOfBuffer - buf.RdOff);
+            let data2 = await this.processor.readBytes(buf.pBuffer, buf.WrOff);
             var data = new Uint8Array(data1.length + data2.length);
             data.set(data1, 0);
             data.set(data2, data1.length);

--- a/src/dap/index.ts
+++ b/src/dap/index.ts
@@ -139,6 +139,22 @@ export interface DAP {
      * @returns Promise
      */
     writeBlock(register: number, values: Uint32Array): Promise<void>;
+
+    /**
+     * Read a block of bytes from a memory access port register
+     * @param register ID of register to read from
+     * @param count The count of values to read
+     * @returns Promise of register data
+     */
+    readBytes(register: number, count: number): Promise<Uint8Array>;
+
+     /**
+      * Write a block of bytes to a memory access port register
+      * @param register ID of register to write to
+      * @param values The values to write
+      * @returns Promise
+      */
+    writeBytes(register: number, values: Uint8Array): Promise<void>;
 }
 
 export * from './adi';


### PR DESCRIPTION
Added functions to read and write non-word-aligned byte sequences. The functions `readBytes()` and `writeBytes()` match those available in pyOCD, and were tested against the word-aligned `readBlock()` and `writeBlock()` functions and the other single word memory functions. They are well behaved in the edge case of zero-length block reads and writes, just like the other block functions.