### PR TITLE
Update to node 20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: 20.x
       - name: Build
         run: |
           npm install


### PR DESCRIPTION
Hi,

I am trying to update the relevant dependencies of dapjs to the latest version.  Note that Node12 is end of life, so this patch updates the node used in the CI to the latest LTS version v20.x .

Apart from this patch, there are more updates to the node package, not sure if they can be submitted? Thank you.