### PR TITLE
RTT example - allow empty lines too

### DIFF
--- a/examples/rtt/web.html
+++ b/examples/rtt/web.html
@@ -120,12 +120,13 @@ SOFTWARE.
             const printable = !ev.altKey && !ev.ctrlKey && !ev.metaKey;
 
             if (ev.keyCode === 13) { // process newline
-                if (line_input.length) {
+                // allow empty lines too
+                // if (line_input.length) {
                     term.write('\r\n');
                     cmd = line_input;
                     console.log('sending: \"' + line_input + '\"');
                     line_input = "";
-                }
+                //}
             } else if (ev.keyCode === 8) { // process backspace
                 if (term._core.buffer.x > 0) {
                     term.write('\b \b');

--- a/examples/rtt/web.html
+++ b/examples/rtt/web.html
@@ -123,7 +123,7 @@ SOFTWARE.
                 // allow empty lines too
                 // if (line_input.length) {
                     term.write('\r\n');
-                    cmd = line_input;
+                    cmd = line_input + "\r\n";
                     console.log('sending: \"' + line_input + '\"');
                     line_input = "";
                 //}
@@ -165,7 +165,7 @@ SOFTWARE.
                 
                 // send to target
                 if (cmd.length) {
-                    cmdBytes = new TextEncoder().encode(cmd + "\r\n");
+                    cmdBytes = new TextEncoder().encode(cmd);
                     ret = await rtt.write(0, cmdBytes);
                     if (ret < 0)
                         console.log("cannot write", cmdBytes, "chars");

--- a/examples/rtt/web.html
+++ b/examples/rtt/web.html
@@ -120,13 +120,10 @@ SOFTWARE.
             const printable = !ev.altKey && !ev.ctrlKey && !ev.metaKey;
 
             if (ev.keyCode === 13) { // process newline
-                // allow empty lines too
-                // if (line_input.length) {
-                    term.write('\r\n');
-                    cmd = line_input + "\r\n";
-                    console.log('sending: \"' + line_input + '\"');
-                    line_input = "";
-                //}
+                term.write('\r\n');
+                cmd = line_input + "\r\n";
+                console.log('sending: \"' + line_input + '\"');
+                line_input = "";
             } else if (ev.keyCode === 8) { // process backspace
                 if (term._core.buffer.x > 0) {
                     term.write('\b \b');


### PR DESCRIPTION
It is typical to just press enter to see if console input is working,
I was very confused that nothing happens so connected to my device via UART to produce some output to RTT,
and only after I found it working I had an idea to actually type some text before pressing enter.

BTW  I could  not test it but hopefully it works, I cloned repo and set up github pages but when trying at https://fanoush.github.io/dapjs/examples/rtt/web.html the page gets 404 on https://fanoush.github.io/dapjs/dist/dap.umd.js
Not sure how I should put stuff to "dist"

EDIT: now I tested it by committing directly to my gh-pages branch and it seems to work