### PR TITLE
Exclude os module from bundler to avoid browser polyfill.

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,6 +11,7 @@ const watch = process.env.ROLLUP_WATCH;
 
 export default {
     input: 'src/index.ts',
+    external: ['os'],
     output: [
         {
             file: pkg.main,


### PR DESCRIPTION
It's only used in `src/transport/hid.ts`, which needs to avoid having the bundler add this browser polyfill.

This looks like the simplest fix, as the `os` is not used by any of the browser related files.

Fixes https://github.com/ARMmbed/dapjs/issues/123.